### PR TITLE
Clear out the DataSource of the grid property after unsaving posts

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -383,7 +383,7 @@ namespace RedditSaveTransfer
                 savedPosts.Remove(listing);
 
             _currentPost = 0;
-            dataGridView1.DataSource = savedPosts[_currentPost].Properties;
+            dataGridView1.DataSource = null;
 
             UpdateSelectionText();
             


### PR DESCRIPTION
This commit fixes issue #9.